### PR TITLE
Refactor UML diagram layout for improved readability

### DIFF
--- a/docs/diagrams/ParserClasses.puml
+++ b/docs/diagrams/ParserClasses.puml
@@ -4,12 +4,15 @@ skinparam arrowThickness 1.1
 skinparam arrowColor LOGIC_COLOR_T4
 skinparam classBackgroundColor LOGIC_COLOR
 
-Class "{abstract}\nCommand" as Command
+Class AddressBookParser
 Class XYZCommand
+Class CommandResult
+Class "{abstract}\nCommand" as Command
+
 
 package "Parser classes"{
 Class "<<interface>>\nParser" as Parser
-Class AddressBookParser
+
 Class XYZCommandParser
 Class CliSyntax
 Class ParserUtil
@@ -22,9 +25,11 @@ Class HiddenOutside #FFFFFF
 HiddenOutside ..> AddressBookParser
 
 AddressBookParser .down.> XYZCommandParser: creates >
+AddressBookParser ..> Command : returns >
+Command <|.. XYZCommand
+XYZCommand ..> CommandResult : returns >
 
 XYZCommandParser ..> XYZCommand : creates >
-AddressBookParser ..> Command : returns >
 XYZCommandParser .up.|> Parser
 XYZCommandParser ..> ArgumentMultimap
 XYZCommandParser ..> ArgumentTokenizer
@@ -34,5 +39,4 @@ CliSyntax ..> Prefix
 XYZCommandParser ..> ParserUtil
 ParserUtil .down.> Prefix
 ArgumentTokenizer .down.> Prefix
-XYZCommand -up-|> Command
 @enduml


### PR DESCRIPTION
- Moved parser-related classes to the right side of the diagram for better organization and clarity.
- Separated `AddressBookParser` from the "Parser classes" package as it does not implement the `Parser` interface.
- Added explicit directional modifiers to ensure consistent vertical alignment of subclass relationships.

This update enhances the readability of the UML diagram by making the structure of parser components more intuitive and accurately representing class dependencies.

close #120 