### PR TITLE
Student and Company commands: change duplicate criteria

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,7 +12,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_CATEGORY = new Prefix("c/");
-    public static final Prefix PREFIX_STUDENTID = new Prefix("s/");
+    public static final Prefix PREFIX_STUDENTID = new Prefix("id/");
     public static final Prefix PREFIX_INDUSTRY = new Prefix("i/");
 
 }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -16,7 +16,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}/][\\p{Alnum}/ ]*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -57,6 +57,7 @@ public abstract class Person {
     public abstract String getCategoryDisplayName();
     public abstract StudentId getStudentId();
     public abstract Industry getIndustry();
+    public abstract boolean isSamePerson(Person otherPerson);
 
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
@@ -64,19 +65,6 @@ public abstract class Person {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
-    }
-
-    /**
-     * Returns true if both persons have the same name.
-     * This defines a weaker notion of equality between two persons.
-     */
-    public boolean isSamePerson(Person otherPerson) {
-        if (otherPerson == this) {
-            return true;
-        }
-
-        return otherPerson != null
-                && otherPerson.getName().equals(getName());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/company/Company.java
+++ b/src/main/java/seedu/address/model/person/company/Company.java
@@ -64,9 +64,13 @@ public class Company extends Person {
             return true;
         }
 
-        return otherPerson != null
-                && otherPerson.getName().equals(getName())
-                && otherPerson.getIndustry().equals(getIndustry());
+        if (otherPerson instanceof Company) {
+            return otherPerson != null
+                    && otherPerson.getName().equals(getName())
+                    && otherPerson.getIndustry().equals(getIndustry());
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/company/Company.java
+++ b/src/main/java/seedu/address/model/person/company/Company.java
@@ -54,6 +54,21 @@ public class Company extends Person {
         return null;
     }
 
+    /**
+     * Returns true if both persons have the same company.
+     * This defines a weaker notion of equality between two companies.
+     */
+    @Override
+    public boolean isSamePerson(Person otherPerson) {
+        if (otherPerson == this) {
+            return true;
+        }
+
+        return otherPerson != null
+                && otherPerson.getName().equals(getName())
+                && otherPerson.getIndustry().equals(getIndustry());
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)

--- a/src/main/java/seedu/address/model/person/student/Student.java
+++ b/src/main/java/seedu/address/model/person/student/Student.java
@@ -51,6 +51,20 @@ public class Student extends Person {
         return null;
     }
 
+    /**
+     * Returns true if both students have the same student id.
+     * This defines a weaker notion of equality between two students.
+     */
+    @Override
+    public boolean isSamePerson(Person otherPerson) {
+        if (otherPerson == this) {
+            return true;
+        }
+
+        return otherPerson != null
+                && otherPerson.getStudentId().equals(getStudentId());
+    }
+
     public void incrementAttendance() {
         attendance++;
     }

--- a/src/main/java/seedu/address/model/person/student/Student.java
+++ b/src/main/java/seedu/address/model/person/student/Student.java
@@ -61,8 +61,11 @@ public class Student extends Person {
             return true;
         }
 
-        return otherPerson != null
-                && otherPerson.getStudentId().equals(getStudentId());
+        if (otherPerson instanceof Student) {
+            return otherPerson != null
+                    && otherPerson.getStudentId().equals(getStudentId());
+        }
+        return false;
     }
 
     public void incrementAttendance() {

--- a/src/main/java/seedu/address/model/person/student/Student.java
+++ b/src/main/java/seedu/address/model/person/student/Student.java
@@ -68,14 +68,6 @@ public class Student extends Person {
         return false;
     }
 
-    public void incrementAttendance() {
-        attendance++;
-    }
-
-    public int getAttendance() {
-        return attendance;
-    }
-
     @Override
     public String toString() {
         return new ToStringBuilder(this)
@@ -92,5 +84,5 @@ public class Student extends Person {
     public String getCategoryDisplayName() {
         return "Student";
     }
-    // Things to add: A list to keep track of event attended
+
 }

--- a/src/main/java/seedu/address/model/person/student/StudentId.java
+++ b/src/main/java/seedu/address/model/person/student/StudentId.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Person's phone number in the address book.
+ * Represents a Student's student id in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidId(String)}
  */
 public class StudentId {


### PR DESCRIPTION
Student duplicates are now handled by Student ID instead of Name, and Company duplicates are now determined by both Industry and Name. This enhances data integrity by ensuring unique identification for students and companies.

Let's improve the uniqueness handling to better support contact management requirements.

Fix #138 Fix #126 