### PR TITLE
Update 'filtertag' command success message and enforce unique keywords

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterTagCommand.java
@@ -3,12 +3,11 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 /**
- * Filters and lists all persons in address book whose tags contain any of the argument keywords.
+ * Filters and lists all persons in the address book whose tags contain any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FilterTagCommand extends Command {
@@ -20,6 +19,8 @@ public class FilterTagCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " friend colleague";
 
+    public static final String MESSAGE_SUCCESS = "%d contact(s) with tag(s): %s listed.";
+
     private final TagContainsKeywordsPredicate predicate;
 
     public FilterTagCommand(TagContainsKeywordsPredicate predicate) {
@@ -30,8 +31,11 @@ public class FilterTagCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
-        return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+        int listSize = model.getFilteredPersonList().size();
+        String keywords = String.join(", ", predicate.getKeywords());
+        String resultMessage = String.format(MESSAGE_SUCCESS, listSize, keywords);
+
+        return new CommandResult(resultMessage);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/FilterTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterTagCommandParser.java
@@ -3,6 +3,9 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import seedu.address.logic.commands.FilterTagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -12,6 +15,9 @@ import seedu.address.model.person.TagContainsKeywordsPredicate;
  * Parses input arguments and creates a new FilterTagCommand object
  */
 public class FilterTagCommandParser implements Parser<FilterTagCommand> {
+
+    public static final String MESSAGE_DUPLICATE_KEYWORDS = "Error: Duplicate keywords found. "
+            + "Please enter unique tag keywords.";
 
     /**
      * Parses the given {@code String} of arguments in the context of the FilterTagCommand
@@ -25,8 +31,14 @@ public class FilterTagCommandParser implements Parser<FilterTagCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterTagCommand.MESSAGE_USAGE));
         }
 
-        String[] tagKeywords = trimmedArgs.split("\\s+");
+        List<String> tagKeywords = Arrays.asList(trimmedArgs.split("\\s+"));
+        Set<String> uniqueKeywords = new HashSet<>(tagKeywords);
 
-        return new FilterTagCommand(new TagContainsKeywordsPredicate(Arrays.asList(tagKeywords)));
+        // Check for duplicates
+        if (uniqueKeywords.size() < tagKeywords.size()) {
+            throw new ParseException(MESSAGE_DUPLICATE_KEYWORDS);
+        }
+
+        return new FilterTagCommand(new TagContainsKeywordsPredicate(tagKeywords));
     }
 }

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -40,4 +40,8 @@ public class TagContainsKeywordsPredicate implements Predicate<Person> {
     public String toString() {
         return new ToStringBuilder(this).add("keywords", keywords).toString();
     }
+
+    public List<String> getKeywords() {
+        return keywords;
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/FilterTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterTagCommandTest.java
@@ -3,8 +3,8 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.FilterTagCommand.MESSAGE_SUCCESS;
 import static seedu.address.testutil.TypicalContacts.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -53,7 +53,7 @@ public class FilterTagCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(MESSAGE_SUCCESS, 0, "");
         TagContainsKeywordsPredicate predicate = preparePredicate(" ");
         FilterTagCommand command = new FilterTagCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/seedu/address/logic/parser/FilterTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterTagCommandParserTest.java
@@ -23,13 +23,19 @@ public class FilterTagCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFilterTagCommand() {
-        // no leading and trailing whitespaces
+        // No leading and trailing whitespaces
         FilterTagCommand expectedFilterTagCommand =
                 new FilterTagCommand(new TagContainsKeywordsPredicate(Arrays.asList("Sponsor", "Friend")));
         assertParseSuccess(parser, "Sponsor Friend", expectedFilterTagCommand);
 
-        // multiple whitespaces between keywords
+        // Multiple whitespaces between keywords
         assertParseSuccess(parser, " \n Sponsor \n \t Friend  \t", expectedFilterTagCommand);
     }
 
+    @Test
+    public void parse_duplicateArgs_throwsParseException() {
+        // Expect an error due to duplicate keywords
+        String duplicateKeywords = "Sponsor Friend Sponsor";
+        assertParseFailure(parser, duplicateKeywords, FilterTagCommandParser.MESSAGE_DUPLICATE_KEYWORDS);
+    }
 }


### PR DESCRIPTION
Fix #136 #137 
Improved clarity of filtertag's command success message.
Stricter handling of duplicate keyword inputs.