### PR TITLE
Fix Inconsistent Error Message for Delete Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -65,7 +65,7 @@ public class DeleteCommand extends Command {
         } else {
             for (Index targetIndex : targetIndices) {
                 if (targetIndex.getZeroBased() >= lastShownList.size()) {
-                    throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+                    throw new CommandException(MESSAGE_INVALID_INDEX_OR_STRING);
                 }
                 Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
                 model.deletePerson(personToDelete);

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,13 +1,13 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENTID_DESC_AMY;
+import static seedu.address.logic.commands.DeleteCommand.MESSAGE_INVALID_INDEX_OR_STRING;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalContacts.AMY;
 
@@ -62,7 +62,7 @@ public class LogicManagerTest {
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandException(deleteCommand, MESSAGE_INVALID_INDEX_OR_STRING);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -90,7 +90,7 @@ public class DeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, DeleteCommand.MESSAGE_INVALID_INDEX_OR_STRING);
     }
 
     @Test
@@ -120,7 +120,7 @@ public class DeleteCommandTest {
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, DeleteCommand.MESSAGE_INVALID_INDEX_OR_STRING);
     }
 
     @Test


### PR DESCRIPTION
### Description:
In PR #181, a new, more appropriate error message was defined for the delete command to handle cases where the list of contacts is empty. However, this error message was not applied consistently across all relevant code paths in the delete command, resulting in inconsistent user feedback when attempting to delete from an empty list.

### Justification:
* **Aligning with Guidelines**: According to the guidelines, a bug is defined as a deviation from the advertised behavior or incorrect behavior due to code issues. The current error message can be considered misleading or not fully representative of the situation when a list is empty, thus not providing accurate feedback.
* **Not an Enhancement:** This change is not an enhancement or a feature addition but a correction of an existing issue where the feedback provided to users is inconsistent and potentially confusing.
* **Exception Clause**: The fix aligns with the guideline clause that allows addressing a bug if the intended behavior was already defined but not fully implemented or if user feedback is incorrect due to an oversight.

### What This Fix Does:
Ensures that the correct error message is shown when attempting to delete from an empty list, improving consistency and user clarity.

### Impact:
This fix ensures users receive proper feedback that aligns with expectations outlined in the UG and the code's intended behavior.