### PR TITLE
Fix the track error behaviour when only one category is in the list

### DIFF
--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -8,8 +8,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
-
-
 /**
  * Represents a command with hidden internal logic and the ability to be executed.
  */
@@ -26,7 +24,7 @@ public abstract class Command {
     public abstract CommandResult execute(Model model) throws CommandException;
 
     /**
-     * Checks if the command can be executed on the contact list.
+     * Checks if the contact list is non-empty so that the command can be executed.
      * @param model {@code Model} which the command should operate on.
      * @param message Message for the exception thrown
      * @throws CommandException If a command is attempted to be executed on an empty contact list.

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -19,7 +19,7 @@ import seedu.address.model.person.student.Student;
 import seedu.address.model.tag.Tag;
 
 /**
- * Adds tag(s) to an existing person in the list without overwriting existing tags.
+ * Adds tag(s) to an existing person in the contact list without overwriting existing tags.
  */
 public class TagCommand extends Command {
 
@@ -59,7 +59,7 @@ public class TagCommand extends Command {
     }
 
     /**
-     * Constructor for adding tags to all persons in the list.
+     * Constructor for adding tags to all persons in the displayed list.
      * @param tagsToAdd Set of tags to be added to all persons.
      */
     public TagCommand(Set<Tag> tagsToAdd) {
@@ -116,7 +116,7 @@ public class TagCommand extends Command {
     }
 
     /**
-     * Checks if the person already has the specified tag, ignoring case.
+     * Checks if the person already has the specified case-insensitive tag.
      * @param person The person to check.
      * @param tag The tag to check for.
      * @return True if the person has the tag, false otherwise.

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -39,8 +39,7 @@ public class TagCommand extends Command {
             + " either be:\n"
             + "1. A positive integer within the size of the list\n"
             + "2. 'all' if you want to add the tag to all contacts in the list.";
-    public static final String MESSAGE_NO_CONTACTS_TO_TAG = "There are no contacts to add tags to.\n"
-            + "Enter the command help to start adding student or company contacts!";
+    public static final String MESSAGE_NO_CONTACTS_TO_TAG = "There are no contacts to add tags to.";
     private final Index index;
     private final Set<Tag> tagsToAdd;
     private final boolean shouldAddToAll;

--- a/src/main/java/seedu/address/logic/commands/TrackCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TrackCommand.java
@@ -43,8 +43,12 @@ public class TrackCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        // Resets to the full complete contact list to work with before filtering
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
         executableList(model, MESSAGE_NO_CONTACTS_TO_TRACK);
 
+        // Filters with the predicate after resetting to the full complete contact list
         model.updateFilteredPersonList(categoryPredicate);
         int size = model.getFilteredPersonList().size();
         return new CommandResult(String.format(MESSAGE_SUCCESS, this.category, size));

--- a/src/main/java/seedu/address/logic/commands/TrackCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TrackCommand.java
@@ -8,7 +8,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.CategoryContainsKeywordPredicate;
 
 /**
- * Tracks and lists all persons in the address book who are in the specified category to the user.
+ * Tracks and lists all persons in the contact list who are in the specified category to the user.
  */
 public class TrackCommand extends Command {
 
@@ -32,6 +32,7 @@ public class TrackCommand extends Command {
     private final String category;
 
     /**
+     * Constructor for tracking and listing all persons from the specified category.
      * @param categoryPredicate the category to track from the list of predefined categories
      */
     public TrackCommand(CategoryContainsKeywordPredicate categoryPredicate) {
@@ -60,7 +61,6 @@ public class TrackCommand extends Command {
             return true;
         }
 
-        // instanceof handles nulls
         if (!(other instanceof TrackCommand t)) {
             return false;
         }

--- a/src/main/java/seedu/address/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagCommandParser.java
@@ -14,7 +14,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new AddTagCommand object
+ * Parses input arguments and creates a new TagCommand object
  */
 public class TagCommandParser implements Parser<TagCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/TrackCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TrackCommandParser.java
@@ -13,7 +13,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.CategoryContainsKeywordPredicate;
 
 /**
- * Parses input arguments and creates a new FindCommand object
+ * Parses input arguments and creates a new TrackCommand object
  */
 public class TrackCommandParser implements Parser<TrackCommand> {
     private static final Set<String> PREDEFINED_CATEGORIES = new HashSet<>(Arrays.asList("student", "company"));
@@ -33,11 +33,11 @@ public class TrackCommandParser implements Parser<TrackCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, TrackCommand.MESSAGE_USAGE));
         }
 
-        // Splits by whitespace to handle multiple words input
+        // Splits by whitespace to handle multiple words input case
         String[] words = trimmedArgs.split("\\s+");
         String category = words[0].toLowerCase(Locale.ROOT);
 
-        // Checks if the provided category to track is in multiple words or not from the predefined list
+        // Checks if the provided category to track is in multiple words or not found in the predefined list
         if (words.length != 1 || !PREDEFINED_CATEGORIES.contains(category)) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_INPUT, TrackCommand.MESSAGE_INVALID_INPUT_ERROR));

--- a/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
@@ -45,13 +45,16 @@ public class TagCommandParserTest {
         // Missing tags or index should throw format error
         String missingTagInput = "1";
         String missingIndexInput = "t/friend";
-        String emptyInput = "";
+        String emptyInput = " ";
+        String missingTagNameInput = "t/ ";
 
         assertParseFailure(parser, missingTagInput,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
         assertParseFailure(parser, missingIndexInput,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
         assertParseFailure(parser, emptyInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, missingTagNameInput,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
@@ -43,18 +43,18 @@ public class TagCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         // Missing tags or index should throw format error
-        String missingTagInput = "1";
+        String missingTagPrefix = "1 e";
         String missingIndexInput = "t/friend";
         String emptyInput = " ";
-        String missingTagNameInput = "t/ ";
+        String onlyTagPrefix = "t/";
 
-        assertParseFailure(parser, missingTagInput,
+        assertParseFailure(parser, missingTagPrefix,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
         assertParseFailure(parser, missingIndexInput,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
         assertParseFailure(parser, emptyInput,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, missingTagNameInput,
+        assertParseFailure(parser, onlyTagPrefix,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
     }
 


### PR DESCRIPTION
Actual behaviour of track differs from the advertised behaviour (i.e., the behaviour stated in the UG) when only 1 category is in the list due to an error in the code.

Close #228