### PR TITLE
Fix tag inconsistent message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -85,20 +85,21 @@ public class TagCommand extends Command {
                     }
                 }
             }
-
             // Adds tags to all contacts
             for (Person person : lastShownList) {
                 Person updatedPerson = addTagsToPerson(person, tagsToAdd);
                 model.setPerson(person, updatedPerson);
             }
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-            return new CommandResult(String.format(MESSAGE_ADD_TAG_TO_ALL_SUCCESS, tagsToAdd));
+
+            String addedTags = addedTagsToString(tagsToAdd);
+
+            return new CommandResult(String.format(MESSAGE_ADD_TAG_TO_ALL_SUCCESS, addedTags));
         } else {
             assert index != null;
             if (index.getZeroBased() >= lastShownList.size()) {
                 throw new CommandException(MESSAGE_INVALID_INDEX_OR_STRING);
             }
-
             assert index.getOneBased() > 0;
             Person personToEdit = lastShownList.get(index.getZeroBased());
             Person updatedPerson = addTagsToPerson(personToEdit, tagsToAdd);
@@ -106,10 +107,7 @@ public class TagCommand extends Command {
             model.setPerson(personToEdit, updatedPerson);
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-            // Concatenates tags for success message
-            String addedTags = tagsToAdd.stream()
-                    .map(Tag::toString)
-                    .collect(Collectors.joining(", "));
+            String addedTags = addedTagsToString(tagsToAdd);
 
             return new CommandResult(String.format(MESSAGE_ADD_TAG_SUCCESS, addedTags, Messages.format(updatedPerson)));
         }
@@ -125,6 +123,17 @@ public class TagCommand extends Command {
         return person.getTags().stream()
                 .map(t -> t.tagName.toLowerCase())
                 .anyMatch(existingTag -> existingTag.equals(tag.tagName.toLowerCase()));
+    }
+
+    /**
+     * Concatenates tags added for success message.
+     * @param tagsAdded The tags added.
+     * @return A string of all tags added.
+     */
+    private String addedTagsToString(Set<Tag> tagsAdded) {
+        return tagsAdded.stream()
+                .map(Tag::toString)
+                .collect(Collectors.joining(", "));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -14,6 +14,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FOURTH_PERSON;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,8 +96,11 @@ public class TagCommandTest {
 
     @Test
     public void execute_addTagToAllContacts_success() {
-        Tag newTag = new Tag("commonTag");
-        Set<Tag> tagsToAdd = Collections.singleton(newTag);
+        Tag commonTag1 = new Tag("commonTag1");
+        Tag commonTag2 = new Tag("commonTag2");
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(commonTag1);
+        tagsToAdd.add(commonTag2);
 
         TagCommand addTagCommand = new TagCommand(tagsToAdd);
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
@@ -110,8 +114,8 @@ public class TagCommandTest {
                     : new CompanyBuilder((Company) person).withTags(tagNames).build();
             expectedModel.setPerson(person, updatedPerson);
         }
-
-        String expectedMessage = String.format(TagCommand.MESSAGE_ADD_TAG_TO_ALL_SUCCESS, tagsToAdd);
+        String addedTags = tagsToAdd.stream().map(Tag::toString).collect(Collectors.joining(", "));
+        String expectedMessage = String.format(TagCommand.MESSAGE_ADD_TAG_TO_ALL_SUCCESS, addedTags);
 
         assertCommandSuccess(addTagCommand, model, expectedMessage, expectedModel);
 


### PR DESCRIPTION
**Rationale for Fixing Tag Success Message Format:**
The current implementation of the tag addition command displays success messages inconsistently when tags are added to all contacts. The output for such commands shows nested brackets (e.g., [[tag1], [tag2]]), differing from the expected format when tags are added to a single contact, which is [tag1], [tag2] without surrounding nested brackets.

**Justification for the Fix:**
Behaviour Not Specifically Stated in the UG: 
While the User Guide does not explicitly mention the expected format for displaying tags in success messages for multiple contacts, the reasonable 'correct' behaviour inferred from user expectations is to ensure consistency in message formatting across different command outputs. This aligns with maintaining a user-friendly and predictable interface.

Clarifying Reasonable Behaviour: 
Following the guideline where behaviour not stated in the UG should default to what is reasonably expected, the correct format should match that of single-contact success messages, avoiding confusion and aligning with user expectations.

User Experience Improvement:
By fixing this inconsistency, the output will be more readable and consistent, enhancing the overall user experience without altering core functionality or introducing new features.


**Proposed Change**
Update the logic in the tag command to ensure that the success message is formatted without nested brackets for consistency, resulting in output like [tag1], [tag2] for all scenarios.

Close #275 