### PR TITLE
Fix no error message bug in import command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -41,7 +41,9 @@ public class ImportCommand extends Command {
 
     public static final String MESSAGE_INVALID_CATEGORY = "Invalid category in CSV. Category must be either 'student' "
             + "or 'company'";
-    public static final String MESSAGE_INVALID_CSV_FORMAT = "Invalid CSV format. File is corrupted or missing compulsory fields.";
+    public static final String MESSAGE_INVALID_CSV_FORMAT = "Invalid CSV format";
+    public static final String MESSAGE_CORRUPTED_CSV_FILE = "File is corrupted or missing compulsory fields\n"
+            + "Please ensure all compulsory fields are present";
     public static final String MESSAGE_NON_CSV_FILE = "The file extension must be .csv";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports contacts from a CSV file.\n"
             + "Parameters: FILE_PATH\n"
@@ -99,7 +101,7 @@ public class ImportCommand extends Command {
         } catch (IOException e) {
             throw new CommandException(String.format(MESSAGE_FAILURE, filePath.toString()));
         } catch (IllegalArgumentException e) {
-            throw new CommandException(MESSAGE_INVALID_CSV_FORMAT);
+            throw new CommandException(MESSAGE_CORRUPTED_CSV_FILE);
         } catch (CommandException e) {
             throw new CommandException(e.getMessage());
         }
@@ -150,11 +152,11 @@ public class ImportCommand extends Command {
     private int addStudent(List<String> values, Model model) throws CommandException {
         String name = values.get(0).trim();
         if (name.isEmpty()) {
-            throw new CommandException("Invalid CSV format: Name cannot be blank for student category");
+            throw new CommandException(MESSAGE_CORRUPTED_CSV_FILE);
         }
         String studentId = values.get(2).trim();
         if (studentId.isEmpty()) {
-            throw new CommandException("Invalid CSV format: Missing Student ID for student category");
+            throw new CommandException("Missing Student ID for student category");
         }
         Student student = new Student(
                 new Name(name),
@@ -182,11 +184,11 @@ public class ImportCommand extends Command {
     private int addCompany(List<String> values, Model model) throws CommandException {
         String name = values.get(0).trim();
         if (name.isEmpty()) {
-            throw new CommandException("Invalid CSV format: Name cannot be blank for company category");
+            throw new CommandException(MESSAGE_CORRUPTED_CSV_FILE);
         }
         String industry = values.get(2).trim();
         if (industry.isEmpty()) {
-            throw new CommandException("Invalid CSV format: Missing Industry for company category");
+            throw new CommandException("Missing Industry for company category");
         }
         Company company = new Company(
                 new Name(name),
@@ -204,12 +206,12 @@ public class ImportCommand extends Command {
         return 0;
     }
 
-     /**
-     * Returns a success message indicating the number of contacts successfully imported.
-     *
-     * @param successCount The number of contacts imported.
-     * @return The success message string.
-     */
+    /**
+    * Returns a success message indicating the number of contacts successfully imported.
+    *
+    * @param successCount The number of contacts imported.
+    * @return The success message string.
+    */
     private String getSuccessMessage(int successCount) {
         return String.format(MESSAGE_SUCCESS, filePath.toString()) + "\nSuccessfully imported: "
                 + successCount + " entries";

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -42,7 +42,7 @@ public class ImportCommand extends Command {
     public static final String MESSAGE_INVALID_CATEGORY = "Invalid category in CSV. Category must be either 'student' "
             + "or 'company'";
     public static final String MESSAGE_INVALID_CSV_FORMAT = "Invalid CSV format";
-    public static final String MESSAGE_CORRUPTED_CSV_FILE = "File is corrupted or missing compulsory fields\n"
+    public static final String MESSAGE_CORRUPTED_CSV_FILE = "File has corrupted or missing compulsory fields\n"
             + "Please ensure all compulsory fields are present and in correct format";
     public static final String MESSAGE_NON_CSV_FILE = "The file extension must be .csv";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports contacts from a CSV file.\n"

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -3,7 +3,10 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.logic.commands.ImportCommand.MESSAGE_CORRUPTED_CSV_FILE;
+import static seedu.address.logic.commands.ImportCommand.MESSAGE_FAILURE;
 import static seedu.address.logic.commands.ImportCommand.MESSAGE_INVALID_CSV_FORMAT;
+import static seedu.address.logic.commands.ImportCommand.MESSAGE_NON_CSV_FILE;
 import static seedu.address.testutil.TypicalContacts.getTypicalAddressBook;
 
 import java.nio.file.Files;
@@ -55,7 +58,7 @@ public class ImportCommandTest {
         ImportCommand importCommand = new ImportCommand(tempFile.toString());
 
         CommandException exception = assertThrows(CommandException.class, () -> importCommand.execute(model));
-        assertEquals(ImportCommand.MESSAGE_INVALID_CATEGORY, exception.getMessage());
+        assertEquals(MESSAGE_CORRUPTED_CSV_FILE, exception.getMessage());
 
         Files.deleteIfExists(tempFile);
     }
@@ -89,24 +92,7 @@ public class ImportCommandTest {
         ImportCommand importCommand = new ImportCommand(tempFile.toString());
 
         CommandException exception = assertThrows(CommandException.class, () -> importCommand.execute(model));
-        assertEquals("Missing Student ID for student category", exception.getMessage());
-
-        Files.deleteIfExists(tempFile);
-    }
-
-    /**
-     * Tests that importing a company contact with a missing industry throws a CommandException.
-     */
-    @Test
-    public void execute_missingIndustry_throwsCommandException() throws Exception {
-        String missingIndustryCsvContent = "name,category,studentID/industry,phone,email,address,tags\n"
-                + "Alice Lee,company,,87654321,alice@example.com,456 Business Ave,colleagues\n"; // Missing industry
-
-        Path tempFile = createTempFile(missingIndustryCsvContent);
-        ImportCommand importCommand = new ImportCommand(tempFile.toString());
-
-        CommandException exception = assertThrows(CommandException.class, () -> importCommand.execute(model));
-        assertEquals("Missing Industry for company category", exception.getMessage());
+        assertEquals(MESSAGE_CORRUPTED_CSV_FILE, exception.getMessage());
 
         Files.deleteIfExists(tempFile);
     }
@@ -255,5 +241,62 @@ public class ImportCommandTest {
         Path tempFile = Files.createTempFile("test", ".csv");
         Files.write(tempFile, content.getBytes());
         return tempFile;
+    }
+
+    @Test
+    public void execute_emptyNameField_throwsCommandException() throws Exception {
+        String csvContent = "name,category,studentID/industry,phone,email,address,tags\n"
+                + ",student,A0123456X,98765432,student@example.com,123 Main St,friends\n";
+
+        Path tempFile = createTempFile(csvContent);
+        ImportCommand importCommand = new ImportCommand(tempFile.toString());
+
+        CommandException exception = assertThrows(CommandException.class, () -> importCommand.execute(model));
+        assertEquals(ImportCommand.MESSAGE_CORRUPTED_CSV_FILE, exception.getMessage());
+
+        Files.deleteIfExists(tempFile);
+    }
+
+    @Test
+    public void execute_emptyIndustryField_throwsCommandException() throws Exception {
+        String csvContent = "name,category,studentID/industry,phone,email,address,tags\n"
+                + "Company XYZ,company,,98765432,company@example.com,456 Industry Rd,business\n";
+
+        Path tempFile = createTempFile(csvContent);
+        ImportCommand importCommand = new ImportCommand(tempFile.toString());
+
+        CommandException exception = assertThrows(CommandException.class, () -> importCommand.execute(model));
+        assertEquals(ImportCommand.MESSAGE_CORRUPTED_CSV_FILE, exception.getMessage());
+
+        Files.deleteIfExists(tempFile);
+    }
+
+    @Test
+    public void execute_insufficientFields_throwsCommandException() throws Exception {
+        String csvContent = "name,category,studentID/industry,phone,email\n"
+                + "Incomplete User,student,A0123456X,98765432,student@example.com\n";
+
+        Path tempFile = createTempFile(csvContent);
+        ImportCommand importCommand = new ImportCommand(tempFile.toString());
+
+        CommandException exception = assertThrows(CommandException.class, () -> importCommand.execute(model));
+        assertEquals(ImportCommand.MESSAGE_INVALID_CSV_FORMAT, exception.getMessage());
+
+        Files.deleteIfExists(tempFile);
+    }
+
+    @Test
+    public void execute_nonCsvFile_throwsCommandException() throws Exception {
+        String nonCsvContent = "This is not a CSV content";
+
+        Path tempFile = Files.createTempFile("tempTxtFile", ".txt");
+        Files.writeString(tempFile, nonCsvContent);
+
+        ImportCommand importCommand = new ImportCommand(tempFile.toString());
+
+        CommandException exception = assertThrows(CommandException.class, () -> importCommand.execute(model));
+        assertEquals(String.format(MESSAGE_FAILURE, tempFile.toString()) + "\n" + MESSAGE_NON_CSV_FILE, exception.getMessage());
+
+        Files.deleteIfExists(tempFile);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -295,7 +295,8 @@ public class ImportCommandTest {
         ImportCommand importCommand = new ImportCommand(tempFile.toString());
 
         CommandException exception = assertThrows(CommandException.class, () -> importCommand.execute(model));
-        assertEquals(String.format(MESSAGE_FAILURE, tempFile.toString()) + "\n" + MESSAGE_NON_CSV_FILE, exception.getMessage());
+        assertEquals(String.format(MESSAGE_FAILURE, tempFile.toString()) + "\n" + MESSAGE_NON_CSV_FILE,
+                exception.getMessage());
 
         Files.deleteIfExists(tempFile);
     }


### PR DESCRIPTION
close #281 

Justification for change in import command
Before: No message was shown when file is corrupted, eg. empty name field, incorrect company etc.
This is because I did not catch the exception in my execute method.
After: Standardised a string, "MESSAGE_CORRUPTED_CSV_FILE" for all errors regarding corrupted CSV file.